### PR TITLE
Bugfix: No longer sends multiple StudentCodeSubmittedEvents on page r…

### DIFF
--- a/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/persistence/entity/grading/CodeAssignmentGradingMetadataEntity.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/persistence/entity/grading/CodeAssignmentGradingMetadataEntity.java
@@ -37,4 +37,7 @@ public class CodeAssignmentGradingMetadataEntity {
 
     @Column(nullable = true, columnDefinition = "TEXT")
     private String feedbackTableHtml;
+
+    @Column(nullable = true)
+    private String lastProcessedCommitSha;
 }

--- a/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/service/GradingService.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/service/GradingService.java
@@ -188,6 +188,9 @@ public class GradingService {
     }
 
 
+    /**
+     * Returns the grading for the current user on the given code assignment.
+     */
     private List<Grading> getCodeAssignmentGradingForStudent(final AssignmentEntity assignment, final LoggedInUser currentUser) {
         GradingEntity gradingEntity = ensureGradingEntityExists(assignment.getId(), currentUser.getId());
         
@@ -621,6 +624,7 @@ public class GradingService {
                 .contentId(assignmentEntity.getAssessmentId())
                 .hintsUsed(0)
                 .success(success)
+                .contentType(ContentProgressedEvent.ContentType.ASSIGNMENT)
                 .timeToComplete(null)
                 .correctness(correctness)
                 .responses(responses)

--- a/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/service/code_assignment/ExternalGrading.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/service/code_assignment/ExternalGrading.java
@@ -2,5 +2,12 @@ package de.unistuttgart.iste.meitrex.assignment_service.service.code_assignment;
 
 import java.time.OffsetDateTime;
 
-public record ExternalGrading(String externalUsername, String status, OffsetDateTime date, String tableHtml, Double achievedPoints, Double totalPoints) {
+public record ExternalGrading(
+        String externalUsername, 
+        String status, 
+        OffsetDateTime date, 
+        String tableHtml, 
+        Double achievedPoints, 
+        Double totalPoints,
+        String commitSha) {
 }

--- a/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/service/code_assignment/GithubClassroom.java
+++ b/src/main/java/de/unistuttgart/iste/meitrex/assignment_service/service/code_assignment/GithubClassroom.java
@@ -280,7 +280,7 @@ public class GithubClassroom implements CodeAssessmentProvider {
                     }
                 }
 
-                gradings.add(new ExternalGrading(username, null, submissionDate, null, achieved, total));
+                gradings.add(new ExternalGrading(username, null, submissionDate, null, achieved, total, null));
             }
 
             return gradings;
@@ -333,9 +333,10 @@ public class GithubClassroom implements CodeAssessmentProvider {
             String status = run.get("status").getAsString();
             String logsUrl = run.get("logs_url").getAsString();
             String lastlyTested = run.get("updated_at").getAsString();
+            String commitSha = run.has("head_sha") ? run.get("head_sha").getAsString() : null;
 
             if (!status.equals("completed")){
-                return new ExternalGrading(null, status, OffsetDateTime.parse(lastlyTested), null, null, null);
+                return new ExternalGrading(null, status, OffsetDateTime.parse(lastlyTested), null, null, null, commitSha);
             }
 
             // Download logs
@@ -377,7 +378,7 @@ public class GithubClassroom implements CodeAssessmentProvider {
                         double totalPoints = Double.parseDouble(matcher.group(1));
                         double maxPoints = Double.parseDouble(matcher.group(2));
                         String tableHtml = extractGradingTableAsHtml(logs);
-                        return new ExternalGrading(null, status, OffsetDateTime.parse(lastlyTested), tableHtml, totalPoints, maxPoints);
+                        return new ExternalGrading(null, status, OffsetDateTime.parse(lastlyTested), tableHtml, totalPoints, maxPoints, commitSha);
                     } else {
                         throw new ExternalPlatformConnectionException("Could not find totalPoints/maxPoints in logs.");
                     }

--- a/src/test/java/de/unistuttgart/iste/meitrex/assignment_service/api/MutationLogAssignmentCompletedTest.java
+++ b/src/test/java/de/unistuttgart/iste/meitrex/assignment_service/api/MutationLogAssignmentCompletedTest.java
@@ -125,6 +125,7 @@ class MutationLogAssignmentCompletedTest {
                 .correctness(35.0/50.0)
                 .hintsUsed(0)
                 .success(true)
+                .contentType(ContentProgressedEvent.ContentType.ASSIGNMENT)
                 .responses(responses)
                 .build();
 
@@ -207,6 +208,7 @@ class MutationLogAssignmentCompletedTest {
                 .correctness(15.0/50.0)
                 .hintsUsed(0)
                 .success(false)
+                .contentType(ContentProgressedEvent.ContentType.ASSIGNMENT)
                 .responses(responses)
                 .build();
 
@@ -294,6 +296,7 @@ class MutationLogAssignmentCompletedTest {
                 .correctness(35.0/50.0)
                 .hintsUsed(0)
                 .success(false)
+                .contentType(ContentProgressedEvent.ContentType.ASSIGNMENT)
                 .responses(responses)
                 .build();
 
@@ -382,6 +385,7 @@ class MutationLogAssignmentCompletedTest {
                 .correctness(1.0f)
                 .hintsUsed(0)
                 .success(true)
+                .contentType(ContentProgressedEvent.ContentType.ASSIGNMENT)
                 .responses(responses)
                 .build();
 

--- a/src/test/java/de/unistuttgart/iste/meitrex/assignment_service/api/QueryGetCodeGradingForAssignmentForStudentTest.java
+++ b/src/test/java/de/unistuttgart/iste/meitrex/assignment_service/api/QueryGetCodeGradingForAssignmentForStudentTest.java
@@ -116,7 +116,7 @@ class QueryGetCodeGradingForAssignmentForStudentTest {
         );
 
         ExternalGrading externalGrading = new ExternalGrading("ext-user", gradingEntity.getCodeAssignmentGradingMetadata().getRepoLink(), OffsetDateTime.now(),
-                "<table>feedback</table>", 42.0, 60.0);
+                "<table>feedback</table>", 42.0, 60.0, "test-commit-sha");
 
         when(codeAssessmentProvider.findRepository(eq(assignment.getExternalId()), any(), any())).thenReturn(gradingEntity.getCodeAssignmentGradingMetadata().getRepoLink());
 
@@ -227,7 +227,8 @@ class QueryGetCodeGradingForAssignmentForStudentTest {
                 OffsetDateTime.now().truncatedTo(ChronoUnit.SECONDS),
                 "<table>feedback</table>",
                 35.0,
-                50.0
+                50.0,
+                "test-commit-sha-2"
         );
         when(codeAssessmentProvider.syncGradeForStudent(eq("https://github.com/user/repo"), any()))
                 .thenReturn(externalGrading);

--- a/src/test/java/de/unistuttgart/iste/meitrex/assignment_service/service/GradingServiceEventPublishingTest.java
+++ b/src/test/java/de/unistuttgart/iste/meitrex/assignment_service/service/GradingServiceEventPublishingTest.java
@@ -42,11 +42,9 @@ class GradingServiceEventPublishingTest {
 
     @Test
     void testPublishStudentCodeSubmittedEvent_Success() throws Exception {
-        // Arrange
         String repoUrl = "https://github.com/org/repo-student";
         StudentCodeSubmission codeSubmission = createMockCodeSubmission(repoUrl);
 
-        // Create the event that would be published
         StudentCodeSubmittedEvent event = StudentCodeSubmittedEvent.builder()
                 .studentId(codeSubmission.getStudentId())
                 .assignmentId(codeSubmission.getAssignmentId())
@@ -58,10 +56,8 @@ class GradingServiceEventPublishingTest {
                 .branch(codeSubmission.getBranch())
                 .build();
 
-        // Act
         topicPublisher.notifyStudentCodeSubmitted(event);
 
-        // Assert
         ArgumentCaptor<StudentCodeSubmittedEvent> eventCaptor = 
                 ArgumentCaptor.forClass(StudentCodeSubmittedEvent.class);
         verify(topicPublisher, times(1)).notifyStudentCodeSubmitted(eventCaptor.capture());
@@ -80,7 +76,6 @@ class GradingServiceEventPublishingTest {
 
     @Test
     void testCodeSubmissionEventContent_AllFieldsPresent() {
-        // Arrange
         String repoUrl = "https://github.com/test/repo";
         String commitSha = "abc123def456";
         OffsetDateTime commitTime = OffsetDateTime.now();
@@ -89,7 +84,6 @@ class GradingServiceEventPublishingTest {
         Map<String, String> files = new HashMap<>();
         files.put("Test.java", "public class Test {}");
 
-        // Act
         StudentCodeSubmittedEvent event = StudentCodeSubmittedEvent.builder()
                 .studentId(studentId)
                 .assignmentId(assignmentId)
@@ -101,7 +95,6 @@ class GradingServiceEventPublishingTest {
                 .branch(branch)
                 .build();
 
-        // Assert
         assertEquals(studentId, event.getStudentId());
         assertEquals(assignmentId, event.getAssignmentId());
         assertEquals(courseId, event.getCourseId());
@@ -114,7 +107,6 @@ class GradingServiceEventPublishingTest {
 
     @Test
     void testCodeSubmission_MultipleFiles() {
-        // Arrange
         StudentCodeSubmission codeSubmission = StudentCodeSubmission.builder()
                 .studentId(studentId)
                 .assignmentId(assignmentId)
@@ -126,7 +118,6 @@ class GradingServiceEventPublishingTest {
                 .files(createMultipleFiles())
                 .build();
 
-        // Act
         StudentCodeSubmittedEvent event = StudentCodeSubmittedEvent.builder()
                 .studentId(codeSubmission.getStudentId())
                 .assignmentId(codeSubmission.getAssignmentId())
@@ -138,7 +129,6 @@ class GradingServiceEventPublishingTest {
                 .branch(codeSubmission.getBranch())
                 .build();
 
-        // Assert
         assertNotNull(event.getFiles());
         assertEquals(5, event.getFiles().size());
         assertTrue(event.getFiles().containsKey("src/Main.java"));
@@ -150,7 +140,6 @@ class GradingServiceEventPublishingTest {
 
     @Test
     void testCodeSubmission_EmptyFiles() {
-        // Arrange
         StudentCodeSubmission codeSubmission = StudentCodeSubmission.builder()
                 .studentId(studentId)
                 .assignmentId(assignmentId)
@@ -162,7 +151,6 @@ class GradingServiceEventPublishingTest {
                 .files(new HashMap<>())
                 .build();
 
-        // Act
         StudentCodeSubmittedEvent event = StudentCodeSubmittedEvent.builder()
                 .studentId(codeSubmission.getStudentId())
                 .assignmentId(codeSubmission.getAssignmentId())
@@ -174,14 +162,12 @@ class GradingServiceEventPublishingTest {
                 .branch(codeSubmission.getBranch())
                 .build();
 
-        // Assert
         assertNotNull(event.getFiles());
         assertTrue(event.getFiles().isEmpty());
     }
 
     @Test
     void testCodeSubmission_VerifyMetadata() {
-        // Arrange
         String repoUrl = "https://github.com/student/assignment-repo";
         String commitSha = "1234567890abcdef";
         OffsetDateTime timestamp = OffsetDateTime.parse("2025-12-15T10:30:00Z");
@@ -198,7 +184,6 @@ class GradingServiceEventPublishingTest {
                 .files(Map.of("Main.java", "code"))
                 .build();
 
-        // Assert
         assertEquals(repoUrl, submission.getRepositoryUrl());
         assertEquals(commitSha, submission.getCommitSha());
         assertEquals(timestamp, submission.getCommitTimestamp());


### PR DESCRIPTION
## Description of changes
No longer sends multiple StudentCodeSubmittedEvents when page is reloaded. Fixes the AI-tutor sending additional proactive feedback.

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [x] automated unit test
- [ ] automated integration test
- [ ] manual, exploratory test

Failing testcases are unrelated to my changes and also on main
    
## Checklist before requesting a review

- [x] My code is easy to understand
- [x] My code follows the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [x] My code fulfills all acceptance criteria
- [x] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [x] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/MEITREX/wiki/tree/main/adr)
- [x] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/MEITREX/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
